### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/kmcginnes/krismcginnes.com/security/code-scanning/1](https://github.com/kmcginnes/krismcginnes.com/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/ci.yml` at the workflow root (just under `on:` and before `jobs:`), so it applies to all jobs unless overridden. For this workflow, the best minimal safe setting is:

- `contents: read`

This preserves existing functionality (checkout + typecheck/lint) while enforcing least privilege for `GITHUB_TOKEN`. No imports, methods, or dependencies are needed—just YAML configuration changes in the shown file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
